### PR TITLE
Handle missing account dict in session validator

### DIFF
--- a/scripts/validate_sessions.py
+++ b/scripts/validate_sessions.py
@@ -36,7 +36,9 @@ OKX_TYPE = "perp"
 
 def enforce_okx_only(inp: dict) -> List[str]:
     errs = []
-    acct = inp.get("account", {})
+    acct = inp.get("account")
+    if not isinstance(acct, dict):
+        acct = {}
     if acct.get("venue") != OKX_VENUE:
         errs.append(f"[input] account.venue must be '{OKX_VENUE}'")
     if acct.get("instrument") != OKX_INSTRUMENT:


### PR DESCRIPTION
## Summary
- avoid crashes when session JSON contains `null` account by normalizing non-dict account values

## Testing
- `python -m py_compile scripts/validate_sessions.py`
- `python - <<'PY'
import importlib.util
spec = importlib.util.spec_from_file_location('validate_sessions', 'scripts/validate_sessions.py')
vs = importlib.util.module_from_spec(spec)
spec.loader.exec_module(vs)
print(vs.enforce_okx_only({'account': None}))
print(vs.enforce_okx_only({'account': {'venue':'Other','instrument':'BTCUSDT.P','type':'perp'}}))
print(vs.enforce_okx_only({'account': {'venue':'OKX','instrument':'BTCUSDT.P','type':'perp'}}))
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a58319594083339e8cdceb02920a51