### PR TITLE
Validate account object in session validator

### DIFF
--- a/scripts/validate_sessions.py
+++ b/scripts/validate_sessions.py
@@ -38,7 +38,8 @@ def enforce_okx_only(inp: dict) -> List[str]:
     errs = []
     acct = inp.get("account")
     if not isinstance(acct, dict):
-        acct = {}
+        errs.append("[input] account must be an object")
+        return errs
     if acct.get("venue") != OKX_VENUE:
         errs.append(f"[input] account.venue must be '{OKX_VENUE}'")
     if acct.get("instrument") != OKX_INSTRUMENT:


### PR DESCRIPTION
## Summary
- ensure account field is an object before enforcing OKX-only checks

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a585599794833381f1c90b501a8173